### PR TITLE
Fix stupid typo that overwrote the ssh_user setting ...

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -50,7 +50,7 @@ if [ -f "/etc/yunohost/hooks.d/backup/17-data_home" ]; then
 fi
 
 if echo "$ssh_user" | grep -v ' '; then
-    ynh_app_setting_set --app=$app --key=ssh_user --value="$(grep -Po 'no-user-rc \K.*$' /home/$ssh_user/.ssh/authorized_keys)"
+    ynh_app_setting_set --app=$app --key=public_key --value="$(grep -Po 'no-user-rc \K.*$' /home/$ssh_user/.ssh/authorized_keys)"
 fi
 
 #=================================================


### PR DESCRIPTION
ping @zamentur 

c.f. https://github.com/YunoHost-Apps/borgserver_ynh/commit/ebb51846381266f4126ed0c979b9e5b66569050f

That should somewhat fix it, but now it's already too late on my server, the setting "ssh_user" already contains the public key (and the "public_key" setting still contains a broken/incomplete value) and there's no obvious easy way to guess what was the true value of the "ssh_user" ...