### PR TITLE
Monitor cron should check /backup/data and not just /backup

### DIFF
--- a/conf/monitor-backup
+++ b/conf/monitor-backup
@@ -1,2 +1,2 @@
 SHELL=/bin/bash
-0 9,20 * * * root : Monitor __SSH_USER__ backup ; ALERT_DELAY="$(yunohost app setting __APP__ alert_delay)"; [[ $(find /home/__SSH_USER__/backup -follow -mtime -${ALERT_DELAY} -ls | wc -l) > 0 ]] || ( echo "No file has been backuped in /home/__SSH_USER__ since ${ALERT_DELAY} days" | mail -s "[YNH] Backup missing : __SSH_USER__" $(yunohost app setting __APP__ alert_mails))
+0 9,20 * * * root : Monitor __SSH_USER__ backup ; ALERT_DELAY="$(yunohost app setting __APP__ alert_delay)"; [[ $(find /home/__SSH_USER__/backup/data -follow -mtime -${ALERT_DELAY} -ls | wc -l) > 0 ]] || ( echo "No file has been backuped in /home/__SSH_USER__ since ${ALERT_DELAY} days" | mail -s "[YNH] Backup missing : __SSH_USER__" $(yunohost app setting __APP__ alert_mails))


### PR DESCRIPTION
## Problem

c.f situation where borg complains about "Data integrity error" ... but on the server side, no complain is made because "lock" files are changed ... despite the lack of changes in the data/ folder ...

## Solution

- Monitor cron  should check the data folder

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
