### PR TITLE
Fix .ssh directory rights

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -37,13 +37,15 @@ ynh_system_user_create --username=$ssh_user --home_dir=/home/$ssh_user --use_she
 home=/home/$ssh_user
 mkdir -p $home/.ssh
 chmod o=--- $home
-chown -R $ssh_user:$ssh_user $home
+chmod 700 $home/.ssh
 touch $home/.ssh/authorized_keys
 extra="--storage-quota $quota"
 if [ "$quota" = "" ]; then
     extra=""
 fi
 echo "command=\"borg serve $extra --restrict-to-repository $home/backup\",no-pty,no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-user-rc $public_key" >> $home/.ssh/authorized_keys
+chmod 600 $home/.ssh/authorized_keys
+chown -R $ssh_user:$ssh_user $home
 
 # Tweak to prevent the backup of the backup itself
 touch $home/.nobackup


### PR DESCRIPTION
## Problem

- ssh connection fails due to bad permissions: 
```
Jul  9 17:31:58 XXX sshd[240651]: Authentication refused: bad ownership or modes for file /home/BORG_USER/.ssh/authorized_keys
Jul  9 17:31:58 XXX sshd[240651]: Failed publickey for BORG_USER from IP port PORT ssh2: PUBLIC_KEY_SIGNATURE
```

## Solution

- Update rights.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
